### PR TITLE
Add Dockerfile. Fixes #60

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM liuchong/rustup:1.34.0 AS builder
+LABEL description="Joystream substrate node"
+
+WORKDIR /substrate-node-joystream
+COPY . /substrate-node-joystream
+ENV TERM=xterm
+
+RUN apt-get update && apt-get install git clang -y \
+    && ./init-wasm.sh \
+    && git clone https://github.com/Joystream/substrate-runtime-joystream.git \
+    && ./build-runtime.sh \
+    && cargo build --release \
+    && cargo install --path ./ \
+    && apt-get remove git clang -y \
+    && rm -rf /var/lib/apt/lists/*
+ENTRYPOINT "/root/.cargo/bin/joystream-node"


### PR DESCRIPTION
Hello! I based this work on the [`rust-wasm`](https://github.com/Joystream/docker-files/blob/master/rust-wasm/Dockerfile) Dockerfile and thanks to @mnaamani suggestion of using Rustup 1.34.0 got it building. To build it on your own, run:

```
$ docker build .
```

I would also suggest creating Joystream's Docker Hub account: https://hub.docker.com/u/joystream